### PR TITLE
refactor to use first-class objects

### DIFF
--- a/spec/bins/BinSpec.js
+++ b/spec/bins/BinSpec.js
@@ -386,4 +386,9 @@ describe('Bins', function () {
     expect(binnedGenomes.get(chocolate_taxon_id).results.count).toEqual(29188);
     expect(binnedGenomes.get(chocolate_taxon_id).region(chocolate_region_name).results.count).toEqual(4087);
   });
+
+  it('should throw with non-numeric param', function() {
+    expect(function() { bins.uniformBinMapper('foo'); }).toThrow('binWidth must be numeric: foo');
+    expect(function() { mapper_200 = bins.fixedBinMapper('bar'); }).toThrow('binsPerGenome must be numeric: bar');
+  })
 });

--- a/spec/bins/BinSpec.js
+++ b/spec/bins/BinSpec.js
@@ -281,7 +281,7 @@ describe('Bins', function () {
     var binnedGenomes = mapper_200.binnedGenomes();
 
     // when
-    var genome = binnedGenomes[chocolate_taxon_id];
+    var genome = binnedGenomes.get(chocolate_taxon_id);
     var firstRegion = genome.regions[chocolate_region_name];
 
     // then
@@ -297,7 +297,7 @@ describe('Bins', function () {
     var binnedGenomes = mapper_200.binnedGenomes();
 
     // when
-    var objBin = binnedGenomes[chocolate_taxon_id].regions[chocolate_region_name].bins[0];
+    var objBin = binnedGenomes.get(chocolate_taxon_id).regions[chocolate_region_name].bins[0];
     var bin2pos = mapper_200.bin2pos(objBin.idx);
     var pos2bin = mapper_200.pos2bin(chocolate_taxon_id, chocolate_region_name, 1);
 
@@ -347,12 +347,12 @@ describe('Bins', function () {
     var binnedGenomes = mapper_200.binnedGenomes();
 
     // when
-    var objBin = binnedGenomes[chocolate_taxon_id].regions[chocolate_region_name].bins[0];
+    var objBin = binnedGenomes.get(chocolate_taxon_id).regions[chocolate_region_name].bins[0];
     binnedGenomes.setResults(binnedResults);
 
     // then
-    expect(objBin.result).toBeDefined();
-    expect(objBin.result.count).toEqual(356);
+    expect(objBin.results).toBeDefined();
+    expect(objBin.results.count).toEqual(356);
 
   });
 
@@ -367,5 +367,16 @@ describe('Bins', function () {
 
     // then
     expect(thrower).toThrow('Bin count mismatch!');
+  });
+
+  it('should roll up result counts to regions and genomes', function() {
+    // given
+    var binnedResults = require('../support/results-fixed_200_bin');
+    var binnedGenomes = mapper_200.binnedGenomes();
+    binnedGenomes.setResults(binnedResults);
+
+    // then
+    expect(binnedGenomes.get(chocolate_taxon_id).results.count).toEqual(29188);
+    expect(binnedGenomes.get(chocolate_taxon_id).regions[chocolate_region_name].results.count).toEqual(4087);
   });
 });

--- a/spec/bins/BinSpec.js
+++ b/spec/bins/BinSpec.js
@@ -231,45 +231,52 @@ describe('Bins', function () {
 
   it('fixedBinMapper should correctly determine bin width for test genomes', function () {
     // given
+    var Genome = require('../../src/genomes').Genome;
     var binSizeFunction = mapper_200._getBinSizeForGenome;
+
     var genomes = {
-      tooSmall: {
+      tooSmall: new Genome({
+        name: 'tooSmall',
         assembledGenomeSize: 2000,
         regions: { // calculated bin size is 10
           a: {size: 1000},
           b: {size: 1000}
         }
-      },
-      A: {
+      }),
+      A: new Genome({
+        name: 'A',
         assembledGenomeSize: 200000,
         regions: { // calculated bin size is 1007; shouldn't it be 1005?
-          a: {size: 1000},
-          b: {size: 1100},
-          c: {size: 197900}
+          a: {name: 'a', size: 1000},
+          b: {name: 'b', size: 1100},
+          c: {name: 'c', size: 197900}
         }
-      },
-      B: {
+      }),
+      B: new Genome({
+        name: 'B',
         assembledGenomeSize: 200000,
         regions: { // cacluated bin size is 1010
-          a: {size: 100},
-          b: {size: 900},
-          c: {size: 198900},
-          UNANCHORED: {}
+          a: {name: 'a', size: 100},
+          b: {name: 'b', size: 900},
+          c: {name: 'c', size: 198900},
+          UNANCHORED: {name: 'UNANCHORED'}
         }
-      },
-      C: {
+      }),
+      C: new Genome({
+        name: 'C',
         assembledGenomeSize: 200000,
         regions: { // cacluated bin size is 1010; shouldn't it be 1006?
-          a: {size: 0},
-          b: {size: 200000},
-          c: {size: 0},
-          UNANCHORED: {}
+          a: {name: 'a', size: 0},
+          b: {name: 'b', size: 200000},
+          c: {name: 'c', size: 0},
+          UNANCHORED: {name: 'UNANCHORED'}
         }
-      }
+      })
     };
 
-    expect(function () { binSizeFunction(genomes.tooSmall) })
-      .toThrow('assembled genome sizes between 1 and 100000 are not supported');
+    expect(function () {
+      binSizeFunction(genomes.tooSmall)
+    }).toThrow('assembled genome sizes between 1 and 100000 are not supported');
 
     expect(binSizeFunction(genomes.A)).toEqual(1007); // TODO this should be 1005?
     expect(binSizeFunction(genomes.B)).toEqual(1010);
@@ -282,7 +289,7 @@ describe('Bins', function () {
 
     // when
     var genome = binnedGenomes.get(chocolate_taxon_id);
-    var firstRegion = genome.regions[chocolate_region_name];
+    var firstRegion = genome.region(chocolate_region_name);
 
     // then
     expect(firstRegion.startBin).toEqual(chocolate_bin);
@@ -297,7 +304,7 @@ describe('Bins', function () {
     var binnedGenomes = mapper_200.binnedGenomes();
 
     // when
-    var objBin = binnedGenomes.get(chocolate_taxon_id).regions[chocolate_region_name].bins[0];
+    var objBin = binnedGenomes.get(chocolate_taxon_id).region(chocolate_region_name).bins[0];
     var bin2pos = mapper_200.bin2pos(objBin.idx);
     var pos2bin = mapper_200.pos2bin(chocolate_taxon_id, chocolate_region_name, 1);
 
@@ -322,7 +329,7 @@ describe('Bins', function () {
     ];
 
     // then
-    throwers.map(function(fn) {
+    throwers.map(function (fn) {
       expect(fn).toThrow('Please supply valid results parameter');
     });
   });
@@ -341,13 +348,13 @@ describe('Bins', function () {
     expect(shouldThrow).toThrow('Results are for fixed_1000_bin bins. Should be fixed_200_bin');
   });
 
-  it('should map result counts to the appropriate bins', function() {
+  it('should map result counts to the appropriate bins', function () {
     // given
     var binnedResults = require('../support/results-fixed_200_bin');
     var binnedGenomes = mapper_200.binnedGenomes();
 
     // when
-    var objBin = binnedGenomes.get(chocolate_taxon_id).regions[chocolate_region_name].bins[0];
+    var objBin = binnedGenomes.get(chocolate_taxon_id).region(chocolate_region_name).bins[0];
     binnedGenomes.setResults(binnedResults);
 
     // then
@@ -356,7 +363,7 @@ describe('Bins', function () {
 
   });
 
-  it('should throw if the largest bin index is greater than the number of bins', function() {
+  it('should throw if the largest bin index is greater than the number of bins', function () {
     // given
     var binnedResults = _.cloneDeep(require('../support/results-fixed_200_bin'));
     var binnedGenomes = mapper_200.binnedGenomes();
@@ -369,7 +376,7 @@ describe('Bins', function () {
     expect(thrower).toThrow('Bin count mismatch!');
   });
 
-  it('should roll up result counts to regions and genomes', function() {
+  it('should roll up result counts to regions and genomes', function () {
     // given
     var binnedResults = require('../support/results-fixed_200_bin');
     var binnedGenomes = mapper_200.binnedGenomes();
@@ -377,6 +384,6 @@ describe('Bins', function () {
 
     // then
     expect(binnedGenomes.get(chocolate_taxon_id).results.count).toEqual(29188);
-    expect(binnedGenomes.get(chocolate_taxon_id).regions[chocolate_region_name].results.count).toEqual(4087);
+    expect(binnedGenomes.get(chocolate_taxon_id).region(chocolate_region_name).results.count).toEqual(4087);
   });
 });

--- a/spec/bins/BinSpec.js
+++ b/spec/bins/BinSpec.js
@@ -2,9 +2,9 @@ describe('Bins', function () {
   // json response to http://data.gramene.org/maps/select?type=genome
   // converted into a commonJS module by prepending json doc with
   // `module.exports = `
-  var _ = require('lodash');
   var genomes = require('../support/genomes.js');
   var binsGenerator = require('../../src/bins');
+  var _ = require('lodash');
   var bins;
   var mapper_2Mb;
   var mapper_200;
@@ -293,7 +293,7 @@ describe('Bins', function () {
 
     // then
     expect(firstRegion.startBin).toEqual(chocolate_bin);
-    expect(firstRegion.bins.length).toEqual(23);
+    expect(firstRegion.binCount()).toEqual(23);
 
     expect(genome.startBin).toEqual(firstRegion.startBin);
     expect(genome.nbins).toEqual(200);
@@ -304,7 +304,7 @@ describe('Bins', function () {
     var binnedGenomes = mapper_200.binnedGenomes();
 
     // when
-    var objBin = binnedGenomes.get(chocolate_taxon_id).region(chocolate_region_name).bins[0];
+    var objBin = binnedGenomes.get(chocolate_taxon_id).region(chocolate_region_name).firstBin();
     var bin2pos = mapper_200.bin2pos(objBin.idx);
     var pos2bin = mapper_200.pos2bin(chocolate_taxon_id, chocolate_region_name, 1);
 
@@ -354,7 +354,7 @@ describe('Bins', function () {
     var binnedGenomes = mapper_200.binnedGenomes();
 
     // when
-    var objBin = binnedGenomes.get(chocolate_taxon_id).region(chocolate_region_name).bins[0];
+    var objBin = binnedGenomes.get(chocolate_taxon_id).region(chocolate_region_name).firstBin();
     binnedGenomes.setResults(binnedResults);
 
     // then

--- a/src/bins.js
+++ b/src/bins.js
@@ -1,23 +1,23 @@
 'use strict';
 
 /*
-  bins - a module for bins defined on an ordered set of maps
-         such as the genomes in Gramene.
+ bins - a module for bins defined on an ordered set of maps
+ such as the genomes in Gramene.
 
-  Bin numbers are global so they can uniquely identify an interval
-  on a chromosome (aka. region). This is why the maps and regions need to be ordered.
+ Bin numbers are global so they can uniquely identify an interval
+ on a chromosome (aka. region). This is why the maps and regions need to be ordered.
 
-  Once the maps have been loaded, you can get a binMapper for a set of bins.
+ Once the maps have been loaded, you can get a binMapper for a set of bins.
 
-  The bins can be defined as follows:
-      a bin size for uniform-width bins in nucleotides
-      an arbitrary set of intervals {taxon_id: , region: , start: , end: }
+ The bins can be defined as follows:
+ a bin size for uniform-width bins in nucleotides
+ an arbitrary set of intervals {taxon_id: , region: , start: , end: }
 
-  bins = require('bins.js')(map_info);
-  mapper_2Mb = bins.binMapper('uniform',2000000);
-  bin = mapper_2Mb.pos2bin(taxon_id, region, position); // returns -1 for positions not in a bin
-  interval = mapper_2Mb.bin2pos(bin); // returns an interval that contains position
-*/
+ bins = require('bins.js')(map_info);
+ mapper_2Mb = bins.binMapper('uniform',2000000);
+ bin = mapper_2Mb.pos2bin(taxon_id, region, position); // returns -1 for positions not in a bin
+ interval = mapper_2Mb.bin2pos(bin); // returns an interval that contains position
+ */
 
 var isNumber = require('is-number');
 var _ = require('lodash');
@@ -170,12 +170,18 @@ module.exports = function(RAW_GENOME_DATA) {
   return {
     uniformBinMapper: function(binWidth) {
       var name = 'uniform_' + binWidth + '_bin';
+      if(!isNumber(binWidth)) {
+        throw new Error('binWidth must be numeric: ' + binWidth);
+      }
       return bins(name, function getGlobalBinWidth() {
         return binWidth;
       })
     },
     fixedBinMapper: function(binsPerGenome) {
       var name = 'fixed_' + binsPerGenome + '_bin';
+      if(!isNumber(binsPerGenome)) {
+        throw new Error('binsPerGenome must be numeric: ' + binsPerGenome);
+      }
       return bins(name, function determineBinWidthForGenome(genome) {
         if (genome.assembledGenomeSize === 0) return 0;
 

--- a/src/genomes.js
+++ b/src/genomes.js
@@ -11,6 +11,10 @@ function Genomes(rawData, binName, bins, getBinSizeForGenome) {
   }
 }
 
+Genomes.prototype.binCount = function() {
+  return this._bins.length;
+};
+
 Genomes.prototype.each = function(iteratee) {
   _.forOwn(this._genomes, iteratee, this);
 };
@@ -47,16 +51,16 @@ function mapGenomesToBins(genomes, getBinSizeForGenome) {
     var tax = genome.taxon_id;
     var binSize = getBinSizeForGenome(genome);
     var genomeBinCount = 0;
-    genome.startBin = bins.length;
+    genome.startBin = genomes.binCount();
     genome.eachRegion(function(region, rname) {
       var nbins = (rname === 'UNANCHORED') ? 1 : Math.ceil(region.size/binSize);
-      region.startBin = bins.length;
+      region.startBin = genomes.binCount();
       for(var j=0; j < nbins; j++) {
         var idx = region.startBin + j;
         var start = j*binSize+1;
         var end = (j+1 === nbins) ? region.size : (j+1)*binSize;
         var bin = {taxon_id:tax, region:rname, start:start, end:end, idx:idx};
-        addBin(bin, genome, region);
+        addBin(bin, genomes, region);
         ++genomeBinCount;
       }
     });
@@ -64,8 +68,8 @@ function mapGenomesToBins(genomes, getBinSizeForGenome) {
   });
 }
 
-function addBin(bin, genome, region) {
-  genome._bins.push(bin);
+function addBin(bin, genomes, region) {
+  genomes._bins.push(bin);
   region._bins.push(bin);
 }
 
@@ -184,8 +188,16 @@ function updateRegionResults(region) {
   return region.results;
 }
 
+Region.prototype.firstBin = function() {
+  return this.binCount() ? this._bins[0] : undefined;
+};
+
 Region.prototype.eachBin = function(iteratee) {
   _.forEach(this._bins, iteratee);
+};
+
+Region.prototype.binCount = function(iteratee) {
+  return this._bins.length;
 };
 
 Region.prototype.reduceBins = function(reducer, initialValue) {

--- a/src/genomes.js
+++ b/src/genomes.js
@@ -1,0 +1,134 @@
+var _ = require('lodash');
+
+function Genomes(rawData, binName, bins, getBinSizeForGenome) {
+  this.binName = binName;
+  this._bins = bins;
+  this._genomes = refactorGenomes(rawData);
+
+  if(getBinSizeForGenome) {
+    this.getBinSizeForGenome = getBinSizeForGenome;
+    this.mapGenomesToBins();
+  }
+}
+
+Genomes.prototype.each = function(iteratee) {
+  _.forOwn(this._genomes, iteratee, this);
+};
+
+Genomes.prototype.get = function(taxonId) {
+  return this._genomes[taxonId];
+};
+
+Genomes.prototype.setResults = function(binnedResults) {
+  checkResultsObject(binnedResults, this._bins.length, this.binName);
+
+  var data = binnedResults.data;
+  for(var i = 0; i < this._bins.length; i++) {
+    var bin = this._bins[i];
+    bin.results = data[bin.idx] || 0;
+  }
+
+  this.each(function(genome) {
+    var gcount = _.reduce(genome.regions, function(gAcc, region) {
+      var rcount = _.reduce(region.bins, function(rAcc, bin) {
+        return rAcc + bin.results.count;
+      }, 0);
+      region.results = {count: rcount};
+      return gAcc + rcount;
+    }, 0);
+    genome.results = {count: gcount};
+  });
+
+};
+
+Genomes.prototype.clearResults = function() {
+  for(var i = 0; i < bins.length; i++) {
+    var bin = bins[i];
+    delete bin.result;
+  }
+};
+
+Genomes.prototype.mapGenomesToBins = function() {
+  this.each(function(genome) {
+    var tax = genome.taxon_id;
+    var binSize = this.getBinSizeForGenome(genome);
+    var genomeBinCount = 0;
+    var bins = this._bins;
+    genome.startBin = bins.length;
+    _.forEach(genome.regions, function(region, rname) {
+      var nbins = (rname === 'UNANCHORED') ? 1 : Math.ceil(region.size/binSize);
+      region.startBin = bins.length;
+      region.bins = [];
+      for(var j=0; j < nbins; j++) {
+        var idx = region.startBin + j;
+        var start = j*binSize+1;
+        var end = (j+1 === nbins) ? region.size : (j+1)*binSize;
+        var bin = {taxon_id:tax, region:rname, start:start, end:end, idx:idx};
+        bins.push(bin);
+        region.bins.push(bin);
+        ++genomeBinCount;
+      }
+    });
+    genome.nbins = genomeBinCount;
+  });
+};
+
+function checkResultsObject(binnedResults, binCount, binName) {
+  var lastBin;
+
+  if(!(binnedResults &&
+    (typeof binnedResults === 'object') &&
+    binnedResults.data &&
+    binnedResults.displayName))
+  {
+    throw new Error('Please supply valid results parameter');
+  }
+
+  if(binnedResults.displayName && binnedResults.displayName !== binName) {
+    throw new Error('Results are for ' + binnedResults.displayName + ' bins. Should be ' + binName);
+  }
+
+  lastBin = _.max(Object.keys(binnedResults.data), function(binId) {
+    return +binId;
+  });
+
+  if(lastBin > binCount) {
+    throw new Error('Bin count mismatch!');
+  }
+}
+
+function refactorGenomes(rawData) {
+  return _(rawData).map(function(d) {
+    var regions = refactorMapRegions(d.regions);
+    var result = {
+      taxon_id: d.taxon_id,
+      assembledGenomeSize: d.length, // does not include UNANCHORED region
+      fullGenomeSize: _.reduce(regions, function(total, region) { return total + region.size}, 0),
+      regions: regions
+    };
+
+    if(result.fullGenomeSize < result.assembledGenomeSize) {
+      throw new Error(
+        'inconsistencies in genome sizes! The assembled length of ' +
+        d.taxon_id + '\'s genome (' + result.assembledGenomeSize +
+        ') is longer than the sum of all regions of that genome (' +
+        result.fullGenomeSize +')'
+      );
+    }
+    return result;
+  }).indexBy('taxon_id').value();
+}
+
+function refactorMapRegions(regions) {
+  var indices = _.range(regions.names.length);
+  var objArr = _.zip(regions.names, regions.lengths, indices).map(function(region) {
+    return {
+      name: region[0],
+      size: region[1],
+      idx: region[2]
+    };
+  });
+  return _.indexBy(objArr, 'name');
+}
+
+module.exports = Genomes;


### PR DESCRIPTION
Create Genomes object to allow both iterating over genomes and using additional functions. (Final motivation, other than making the code a bit clearer was that otherwise iterating over all genomes would also iterate over setResults, etc)
